### PR TITLE
fix(wait-db): check DNS resolution from PHP container before migrations

### DIFF
--- a/stack/docker.php
+++ b/stack/docker.php
@@ -148,6 +148,7 @@ function waitDbContainer(int $attempt = 0): void
     $context = context();
     $STACK_NAME = $context->environment['STACK_NAME'];
     $dbContainer = "{$STACK_NAME}_db";
+    $phpContainer = "{$STACK_NAME}_php";
     $maxAttempts = 60;
 
     if ($attempt > 0) {
@@ -171,4 +172,27 @@ function waitDbContainer(int $attempt = 0): void
         sleep(1);
         waitDbContainer($attempt + 1);
     }
+
+    $phpContainerId = trim(capture("docker ps --filter name={$phpContainer} -q", context: context()->withAllowFailure()));
+    if ($phpContainerId === '') {
+        io()->warning("PHP container not found, skipping DNS connectivity check.");
+        return;
+    }
+
+    io()->info("Checking database DNS resolution from PHP container...");
+    $dnsMaxAttempts = 30;
+    for ($i = 0; $i < $dnsMaxAttempts; $i++) {
+        $result = run(
+            "docker exec {$phpContainerId} php -r \"@stream_socket_client('tcp://db:5432', \\\$e, \\\$m, 2) ? exit(0) : exit(1);\"",
+            context: context()->withAllowFailure()
+        );
+        if ($result->isSuccessful()) {
+            io()->success("Database is reachable from PHP container!");
+            return;
+        }
+        io()->warning("Database not yet reachable from PHP container, retrying... ({$i}/{$dnsMaxAttempts})");
+        sleep(2);
+    }
+
+    throw new \RuntimeException("Database host 'db' is not reachable from PHP container after {$dnsMaxAttempts} attempts.");
 }


### PR DESCRIPTION
## Summary
- Le healthcheck Postgres (`pg_isready`) confirme que le container DB est prêt, mais le DNS overlay Swarm peut ne pas encore résoudre `db` côté PHP
- `waitDbContainer` vérifie maintenant la connectivité TCP `db:5432` depuis le container PHP (jusqu'à 30 tentatives, 2s d'intervalle) avant de rendre la main
- Corrige les erreurs intermittentes "could not translate host name db" au deploy

## Test plan
- [ ] `make undeploy && make deploy` — vérifier que les migrations passent sans erreur DNS
- [ ] Répéter 3-4 fois pour confirmer la disparition du race condition