### PR TITLE
fix: add missing capture and run imports in docker.php

### DIFF
--- a/stack/docker.php
+++ b/stack/docker.php
@@ -5,8 +5,10 @@ namespace Barlito\Castor;
 use Castor\Attribute\AsTask;
 use Castor\Exception\WaitFor\DockerContainerStateException;
 
-use function Castor\io;
+use function Castor\capture;
 use function Castor\context;
+use function Castor\io;
+use function Castor\run;
 use function Castor\wait_for_docker_container;
 
 #[AsTask('wait-php-container')]


### PR DESCRIPTION
## Summary
- Le DNS connectivity check dans `waitDbContainer` utilise `capture()` et `run()` mais les imports ont été supprimés lors du cleanup refactor
- Ajoute les `use function` manquants

## Test plan
- [ ] `make deploy` — vérifier que le wait-db-container fonctionne sans erreur