### PR TITLE
fix(wait-db): return after recursion so the DNS probe isn't re-run on unwind

### DIFF
--- a/stack/docker.php
+++ b/stack/docker.php
@@ -38,6 +38,8 @@ function waitPhpContainer(int $attempt = 0): void
         }
         sleep(1);
         waitPhpContainer($attempt + 1);
+
+        return;
     }
 }
 
@@ -68,7 +70,14 @@ function waitDbContainer(int $attempt = 0): void
             throw $e;
         }
         sleep(1);
+        // The recursive call performs the full readiness check (container health
+        // AND the DNS probe below). Returning here prevents the parent frames from
+        // re-running the DNS probe as the recursion unwinds — otherwise it is
+        // executed once per elapsed startup second, spamming the output and making
+        // the step look stuck on the first (slow) deploy.
         waitDbContainer($attempt + 1);
+
+        return;
     }
 
     $phpContainerId = trim(capture("docker ps --filter name={$phpContainer} -q", context: context()->withAllowFailure()));


### PR DESCRIPTION
## Problème

`waitDbContainer()` (task castor `wait-db-container`) fait une **récursion dans son `catch`** tant que le conteneur DB n'est pas `healthy`, **sans `return` après**. Conséquence : une fois que le niveau le plus profond réussit, **chaque frame parent retombe dans le bloc de vérif DNS** et le ré-exécute au dépilement de la récursion.

Résultat observé : « Database container is ready! » s'affiche **une fois**, puis « Checking database DNS resolution… / reachable » est imprimé **une fois par seconde d'init** du conteneur. Sur un **premier déploiement** (init Postgres lente, `start_period: 60s`), ça spamme des dizaines de lignes et donne l'impression que l'étape est **bloquée** → on annule le job → `doctrine.migrate` (qui passe après) ne tourne jamais → schéma absent → worker en crash-loop.

Repéré en déployant `dog-help-scheduler` (épinglé sur `master`). `carapp` n'était pas touché car épinglé sur `29beee1`, **avant** l'ajout de la sonde DNS (`9d88f80`).

## Fix

`return;` après l'appel récursif — la récursion effectue déjà la vérif complète (santé conteneur **et** sonde DNS). Même `return` défensif ajouté dans `waitPhpContainer` (même anti-pattern, inoffensif aujourd'hui).

## Test

Pas de test auto sur ces tasks d'infra ; vérifié par lecture du flux de contrôle. Re-déploiement de dog-help à valider une fois mergé + bump du submodule.