### PR TITLE
feat(deploy): run composer.outdated after security check on deploy

### DIFF
--- a/stack/deployment.mk
+++ b/stack/deployment.mk
@@ -12,6 +12,7 @@ deploy:
 	make doctrine.migrate
 	make doctrine.load_fixtures
 	make symfony.security_check
+	-make composer.outdated
 
 ### CI/CD rules
 deploy.ci:


### PR DESCRIPTION
## Summary
- Run `composer.outdated` automatically at the end of the dev `deploy` target, right after `symfony.security_check`.
- The leading `-` tells make to ignore a non-zero exit code, so the outdated report can never break the deployment (as required by the issue).

Only the dev `deploy` target is touched: `deploy.ci` has its security check commented out and `deploy.prod` doesn't run composer at all.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)