### PR TITLE
feat(code-style): add CS Fixer rules for Castor php files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ import('make/castor_entrypoint.php');
 | `composer.outdated` | Show outdated direct deps |
 | `composer.validate` | Validate composer.json |
 | `cs_fixer` / `cs_fixer.dry_run` | PHP CS Fixer (fix / check) |
+| `cs_fixer.castor` / `cs_fixer.castor.dry_run` | PHP CS Fixer on Castor files (fix / check) |
 | `phpcs` | PHP CodeSniffer |
 | `phpmd` | PHP Mess Detector |
 | `phpstan` | PHPStan static analysis |
@@ -89,6 +90,7 @@ import('make/castor_entrypoint.php');
 CSFIXER_OPT ?=     # Extra options for PHP CS Fixer
 PHPSTAN_OPT ?=     # Extra options for PHPStan
 RECTOR_OPT ?=      # Extra options for Rector
+castor_paths ?= castor.php  # Castor files targeted by cs_fixer.castor
 PHPUNIT_OPT ?=     # Extra options for PHPUnit
 BEHAT_OPT ?=       # Extra options for Behat
 node_image ?= node:22  # Node.js Docker image

--- a/app/code_style.mk
+++ b/app/code_style.mk
@@ -3,6 +3,7 @@
 CSFIXER_OPT ?=
 PHPSTAN_OPT ?=
 RECTOR_OPT ?=
+castor_paths ?= castor.php
 
 ### Batch install
 code_quality.install:
@@ -22,12 +23,14 @@ check_style:
 	make phpcs
 	make phpmd
 	make cs_fixer.dry_run
+	make cs_fixer.castor.dry_run
 	make phpstan
 	make rector.dry_run
 
 ### Aggregate fixes
 fix_style:
 	make cs_fixer
+	make cs_fixer.castor
 	make rector
 
 ### PHP CodeSniffer
@@ -53,6 +56,12 @@ cs_fixer:
 
 cs_fixer.dry_run:
 	docker exec -t $(app_container_id) php -d "memory_limit=-1" vendor/bin/php-cs-fixer fix --dry-run --diff --config=$(config_cs_fixer) $(CSFIXER_OPT)
+
+cs_fixer.castor:
+	docker exec -t $(app_container_id) php -d "memory_limit=-1" vendor/bin/php-cs-fixer fix $(castor_paths) --diff --config=$(config_cs_fixer) $(CSFIXER_OPT)
+
+cs_fixer.castor.dry_run:
+	docker exec -t $(app_container_id) php -d "memory_limit=-1" vendor/bin/php-cs-fixer fix $(castor_paths) --dry-run --diff --config=$(config_cs_fixer) $(CSFIXER_OPT)
 
 ### PHPStan
 phpstan.install:


### PR DESCRIPTION
## Summary
- New `cs_fixer.castor` / `cs_fixer.castor.dry_run` rules running PHP CS Fixer on the consuming project's Castor files.
- Target paths are controlled by a new overridable variable `castor_paths ?= castor.php` (php-cs-fixer's default `override` path-mode makes the CLI paths replace the config finder, so only the Castor files are scanned while keeping the shared ruleset from `config_cs_fixer`).
- Wired into the `check_style` (dry-run) and `fix_style` aggregates.
- README updated (rule table + overridable variables).

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)