### PR TITLE
feat(code-style): run composer.validate in check_style

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import('make/castor_entrypoint.php');
 | `phpmd` | PHP Mess Detector |
 | `phpstan` | PHPStan static analysis |
 | `rector` / `rector.dry_run` | Rector refactoring |
-| `check_style` | Run phpcs + phpmd + cs_fixer.dry_run |
+| `check_style` | Run composer.validate + phpcs + phpmd + cs_fixer.dry_run |
 | `phpunit` | Run PHPUnit tests |
 | `behat` / `behat.init` | Run/init Behat |
 | `doctrine.migrate` | Create DB + run migrations |

--- a/app/code_style.mk
+++ b/app/code_style.mk
@@ -19,6 +19,7 @@ test.install:
 
 ### Aggregate checks
 check_style:
+	make composer.validate
 	make phpcs
 	make phpmd
 	make cs_fixer.dry_run


### PR DESCRIPTION
## Summary
- The `composer.validate` rule requested by #1 already exists in `app/composer.mk` (added in a570d6b) but was never wired anywhere.
- This PR adds it to the `check_style` aggregate so `composer.json` is validated (`--strict`) alongside the other quality checks.
- README updated accordingly.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)