### PR TITLE
chore: retire phpmd de check_style (incompatible PHP 8.1+)

### DIFF
--- a/app/code_style.mk
+++ b/app/code_style.mk
@@ -7,7 +7,6 @@ RECTOR_OPT ?=
 ### Batch install
 code_quality.install:
 	make phpcs.install
-	make phpmd.install
 	make cs_fixer.install
 	make phpstan.install
 	make rector.install
@@ -21,7 +20,6 @@ test.install:
 check_style:
 	make composer.validate
 	make phpcs
-	make phpmd
 	make cs_fixer.dry_run
 	make phpstan
 	make rector.dry_run


### PR DESCRIPTION
phpmd repose sur **pdepend**, dont le parser plafonne à **PHP 8.0** (`PHPParserVersion80`). Dès qu'un projet se modernise en 8.1+ (constantes typées `const string`, `new Foo()->method()` du 8.4…), pdepend lève une `UnexpectedTokenException` et phpmd échoue. Vérifié empiriquement : même **phpmd `dev-master`** (pdepend 2.16.2) plante, et il n'existe **aucune release stable** corrigée (la 3.x traîne en dev).

→ On retire `make phpmd` de `check_style` et de `code_quality.install`. Les cibles `phpmd` / `phpmd.install` restent définies pour un usage manuel éventuel.

Découvert en migrant carapp en PHP 8.4.